### PR TITLE
Exclude individual post pages ("&d=XXXX...")

### DIFF
--- a/imdb.lua
+++ b/imdb.lua
@@ -46,7 +46,8 @@ allowed = function(url, parenturl)
 
   if string.match(url, "/nest/")
      or string.match(url, "/inline/")
-     or string.match(url, "/flat/") then
+     or string.match(url, "/flat/") 
+     or string.match(url, "[?&]d=") then
     return false
   end
 


### PR DESCRIPTION
Are post permalinks (I guess they're not so permanent now) really needed, i.e. isn't that content already in the threads? May save scraping time to just get the threads.
WARNING: This is the first Lua code I've ever written and it's untested